### PR TITLE
feat: display comment count in events page

### DIFF
--- a/meethub/events/templates/events/list_of_events.html
+++ b/meethub/events/templates/events/list_of_events.html
@@ -98,6 +98,12 @@
                                     <span class="font-weight-bold text-primary">{{ event.get_number_of_attendees }}</span>
                                     <span class="text-muted ml-1">attending</span>
                                 </div>
+
+                                <div class="d-flex align-items-center mt-1">
+                                    <i class="fas fa-comments text-primary mr-2"></i>
+                                    <span class="font-weight-bold text-primary">{{ event.get_comments_number }}</span>
+                                    <span class="text-muted ml-1">comment{{ event.get_comments_number|pluralize }}</span>
+                                </div>
                             </div>
                             <div class="col-4 text-right">
                                 <a href="{% url 'events:event-detail' event.id %}" class="btn btn-primary btn-sm">


### PR DESCRIPTION
This PR includes the comment count for each event on the event list page `/events`. It uses the `get_comments_number` method from the `Event` model. The word “comment” is pluralized based on the count.

Closes #36

<img width="505" height="257" alt="Image" src="https://github.com/user-attachments/assets/60ba22eb-0d30-473b-a084-4f3ac146776c" />