### PR TITLE
feat: Enhance EventForm with Tempus Dominus widgets (#35)

### DIFF
--- a/meethub/events/forms.py
+++ b/meethub/events/forms.py
@@ -10,13 +10,29 @@ class EventForm(forms.ModelForm):
         widget=forms.Select(attrs={'class': 'form-control'})
     )
 
+    time = forms.TimeField(
+        input_formats=['%I:%M %p', '%H:%M'],  # Acepta '02:30 PM' y '14:30'
+        widget=forms.TextInput(attrs={
+            'class': 'form-control',
+            'id': 'datetimepicker2',
+            'data-td-target': '#datetimepicker2'
+        })
+    )
+
+    date = forms.DateField(
+        input_formats=['%m/%d/%Y', '%Y-%m-%d'],  # Ajusta según el formato de tu widget
+        widget=forms.TextInput(attrs={
+            'class': 'form-control',
+            'id': 'datetimepicker1',
+            'data-td-target': '#datetimepicker1'
+        })
+    )
+
     class Meta:
         model = Event
         fields = ('category', 'name', 'details', 'venue', 'time', 'date',)
         widgets = {
             'name': forms.TextInput(attrs={'class': 'form-control'}),
             'venue': forms.TextInput(attrs={'class': 'form-control'}),
-            'date': forms.DateInput(attrs={'class': 'form-control', 'type': 'date'}),
-            'time': forms.TimeInput(attrs={'class': 'form-control', 'type': 'time'}),
         }
 

--- a/meethub/events/templates/events/base.html
+++ b/meethub/events/templates/events/base.html
@@ -6,12 +6,14 @@
 
 <html lang="en">
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta charset="UTF-8">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css" integrity="sha384-9gVQ4dYFwwWSjIDZnLEWnxCjeSWFphJiwGPXr1jddIhOegiu1FwO5qRGvFXOdJZ4" crossorigin="anonymous">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-    
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<meta charset="UTF-8">
+
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css" integrity="sha384-9gVQ4dYFwwWSjIDZnLEWnxCjeSWFphJiwGPXr1jddIhOegiu1FwO5qRGvFXOdJZ4" crossorigin="anonymous">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tempusdominus-bootstrap-4@5.39.0/build/css/tempusdominus-bootstrap-4.min.css" />
+
     <title>{% block title %}MeetHub - Connect, Meet, Experience{% endblock %}</title>
     
     <style>
@@ -288,9 +290,22 @@
         {% endblock %}
     </div>
 
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js" integrity="sha384-cs/chFZiN24E4KMATLdqdvsezGxaGsi4hLGOzlXwp5UZB1LY//20VyM2taTB4QvJ" crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js" integrity="sha384-uefMccjFJAIv6A+rW+L4AHf99KvxDjWSu1z9VI8SKNVmz4sk7buKt/6v9KI65qnm" crossorigin="anonymous"></script>
-    <script src="{% static 'javascript/main.js' %}"></script>
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/moment@2.29.1/moment.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.14.3/dist/umd/popper.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.1.0/dist/js/bootstrap.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/tempusdominus-bootstrap-4@5.39.0/build/js/tempusdominus-bootstrap-4.min.js"></script>
+
+<!-- Initialization of the datetimepickers -->
+<script>
+  $(function () {
+    $('#datetimepicker1').datetimepicker({
+      format: 'L' // Local Date
+    });
+    $('#datetimepicker2').datetimepicker({
+      format: 'LT' // Local Time
+    });
+  });
+</script>
 </body>
 </html>

--- a/meethub/events/templates/events/create_form.html
+++ b/meethub/events/templates/events/create_form.html
@@ -69,10 +69,22 @@
                                     {{ form.name|as_crispy_field }}
                                 </div>
                                 <div class="col-md-6 mb-3">
-                                    {{ form.date|as_crispy_field }}
+                                    <label for="datetimepicker1" class="form-label">Date</label>
+                                    <div class="input-group date" id="datetimepicker1" data-target-input="nearest">
+                                        <input type="text" name="{{ form.date.name }}" class="form-control datetimepicker-input" data-target="#datetimepicker1" />
+                                        <div class="input-group-append" data-target="#datetimepicker1" data-toggle="datetimepicker">
+                                            <div class="input-group-text"><i class="fa fa-calendar"></i></div>
+                                        </div>
+                                    </div>
                                 </div>
                                 <div class="col-md-6 mb-3">
-                                    {{ form.time|as_crispy_field }}
+                                    <label for="datetimepicker2" class="form-label">Time</label>
+                                    <div class="input-group date" id="datetimepicker2" data-target-input="nearest">
+                                        <input type="text" name="{{ form.time.name }}" class="form-control datetimepicker-input" data-target="#datetimepicker2" />
+                                        <div class="input-group-append" data-target="#datetimepicker2" data-toggle="datetimepicker">
+                                            <div class="input-group-text"><i class="fa fa-clock"></i></div>
+                                        </div>
+                                    </div>
                                 </div>
                                 <div class="col-12 mb-3">
                                     {{ form.venue|as_crispy_field }}

--- a/meethub/events/templates/events/update_form.html
+++ b/meethub/events/templates/events/update_form.html
@@ -61,10 +61,22 @@
                                     {{ form.name|as_crispy_field }}
                                 </div>
                                 <div class="col-md-6 mb-3">
-                                    {{ form.date|as_crispy_field }}
+                                    <label for="datetimepicker1" class="form-label">Date</label>
+                                    <div class="input-group date" id="datetimepicker1" data-target-input="nearest">
+                                        <input type="text" name="{{ form.date.name }}" class="form-control datetimepicker-input" data-target="#datetimepicker1" />
+                                        <div class="input-group-append" data-target="#datetimepicker1" data-toggle="datetimepicker">
+                                            <div class="input-group-text"><i class="fa fa-calendar"></i></div>
+                                        </div>
+                                    </div>
                                 </div>
                                 <div class="col-md-6 mb-3">
-                                    {{ form.time|as_crispy_field }}
+                                    <label for="datetimepicker2" class="form-label">Time</label>
+                                    <div class="input-group date" id="datetimepicker2" data-target-input="nearest">
+                                        <input type="text" name="{{ form.time.name }}" class="form-control datetimepicker-input" data-target="#datetimepicker2" />
+                                        <div class="input-group-append" data-target="#datetimepicker2" data-toggle="datetimepicker">
+                                            <div class="input-group-text"><i class="fa fa-clock"></i></div>
+                                        </div>
+                                    </div>
                                 </div>
                                 <div class="col-12 mb-3">
                                     {{ form.venue|as_crispy_field }}


### PR DESCRIPTION
**Description:**

This PR improves the user experience of the EventForm by replacing the default HTML5 date and time inputs with Tempus Dominus date/time pickers, as requested in issue #35.

✅ Replaces inputs in Create and Update Event pages
✅ Form continues to save date and time correctly
✅ Styling and JS integration tested and working

**🖼️ Screenshots:**

Date preview:

<img width="400"  alt="date-preview" src="https://github.com/user-attachments/assets/c8bce72e-60ff-43d9-af97-50d7c1dfcfe7" />


Time preview:

<img width="400"  alt="time-preview" src="https://github.com/user-attachments/assets/8a867f24-998a-4b58-9595-f2f2a3f0bb11" /> <br>

📌 **Notes**
While working on this issue, I noticed that the "Category" field in the event creation form is required, but no default categories exist in the database. This prevents event creation unless a category is manually added via admin. This might be worth addressing in a separate issue.

Closes #35 